### PR TITLE
remove platform-dependent flag option from find

### DIFF
--- a/bin/mvmult
+++ b/bin/mvmult
@@ -7,6 +7,6 @@ DEST_DIR=$3
 if [[ -z $DEST_DIR ]]; then
     echo "Call like this: mvmult <search-dir> <file-matching-regex> <destination-dir>. (It's all case-sensitive)";
 else
-    find -E "${1}" -regex "${2}" -exec mv -v "{}" "${3}"  \;
+    find "${1}" -regex "${2}" -exec mv -v "{}" "${3}"  \;
 fi
 


### PR DESCRIPTION
the "-E" flag for enabling extended-regular-expressions is not supported on the Linux distros, only on macos. this change limits the user to "basic" regular expressions, which is truly powerful enough for filepath matching.